### PR TITLE
Fix half calculation when editing split transactions

### DIFF
--- a/src/components/EditTransactionModal.jsx
+++ b/src/components/EditTransactionModal.jsx
@@ -17,8 +17,13 @@ export default function EditTransactionModal({ tx, friend, onClose, onSave }) {
 
   function validate() {
     if (!isSplit) return "Only split transactions can be edited.";
-    const num = parseFloat(bill);
-    if (isNaN(num) || num <= 0) return "Enter a valid total amount.";
+    const trimmed = bill.trim();
+    if (!trimmed) return "Enter a valid total amount.";
+    if (!/^\d+(\.\d{0,2})?$/.test(trimmed)) {
+      return "Enter a valid total amount.";
+    }
+    const num = Number(trimmed);
+    if (!Number.isFinite(num) || num <= 0) return "Enter a valid total amount.";
     if (payer !== "you" && payer !== "friend") return "Invalid payer.";
     return "";
   }
@@ -28,8 +33,8 @@ export default function EditTransactionModal({ tx, friend, onClose, onSave }) {
     const v = validate();
     if (v) return setErr(v);
 
-    const rawTotal = parseFloat(bill);
-    const total = roundToCents(rawTotal);
+    const sanitized = bill.trim();
+    const total = roundToCents(Number(sanitized));
     if (total <= 0) {
       setErr("Enter a valid total amount.");
       return;


### PR DESCRIPTION
### **User description**
## Summary
- recompute the half share and delta when editing a split so the payload stays valid

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f4fa118c888325ac5e6f22af076dc5


___

### **PR Type**
Bug fix


___

### **Description**
- Simplify half calculation logic in split transaction editing

- Remove unnecessary share1/share2 computation and min/max logic

- Use single `half` variable for cleaner delta calculation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parse total amount"] --> B["Calculate half = total / 2"]
  B --> C["Compute delta based on payer"]
  C --> D["Update transaction payload"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EditTransactionModal.jsx</strong><dd><code>Simplify half calculation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/EditTransactionModal.jsx

<ul><li>Replaced complex share1/share2 calculation with single <code>half</code> variable<br> <li> Removed unnecessary min/max logic for determining friend's share<br> <li> Simplified delta calculation to directly use <code>half</code> value<br> <li> Maintains same functional behavior with cleaner code</ul>


</details>


  </td>
  <td><a href="https://github.com/tasosbeast/bill-split/pull/7/files#diff-c368d507862a4b6fb1a91e882f721b29cdd489fb5d76fafafd17a0b38205299b">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

