### PR TITLE
Allow any participant to pay group splits

### DIFF
--- a/src/components/SplitForm.jsx
+++ b/src/components/SplitForm.jsx
@@ -61,17 +61,6 @@ export default function SplitForm({ friends, defaultFriendId, onSplit }) {
     setAddFriendId("");
   }, [defaultFriendId]);
 
-  useEffect(() => {
-    if (friendParticipants.length > 1) {
-      if (payer !== YOU_ID) {
-        setPayer(YOU_ID);
-      }
-      if (error === "Group splits must be paid by you.") {
-        setError("");
-      }
-    }
-  }, [friendParticipants, payer, error]);
-
   const selectableFriends = useMemo(
     () => friends.filter((f) => !participantIds.has(f.id)),
     [friends, participantIds]
@@ -84,8 +73,6 @@ export default function SplitForm({ friends, defaultFriendId, onSplit }) {
   }, [bill]);
 
   const totalParticipants = participants.length;
-  const isGroupSplit = friendParticipants.length > 1;
-
   const sumOfInputs = useMemo(() => {
     let sum = 0;
     for (const p of participants) {
@@ -236,12 +223,6 @@ export default function SplitForm({ friends, defaultFriendId, onSplit }) {
       nextPayer = YOU_ID;
     }
 
-    if (friendIds.length > 1 && nextPayer !== YOU_ID) {
-      // This check is now primarily a safeguard. The UI should prevent this state.
-      setError("Group splits must be paid by you.");
-      return;
-    }
-
     const transaction = buildSplitTransaction({
       total: rawTotal,
       payer: nextPayer,
@@ -378,7 +359,6 @@ export default function SplitForm({ friends, defaultFriendId, onSplit }) {
           className="select"
           value={payer}
           onChange={(e) => setPayer(e.target.value)}
-          disabled={isGroupSplit}
         >
           <option value={YOU_ID}>You</option>
           {participants
@@ -392,11 +372,6 @@ export default function SplitForm({ friends, defaultFriendId, onSplit }) {
               );
             })}
         </select>
-        {isGroupSplit && (
-          <div className="helper">
-            Group splits can currently only be paid by you.
-          </div>
-        )}
       </div>
 
       <div>


### PR DESCRIPTION
### **User description**
## Summary
- remove the UI restriction forcing group bills to be paid by you
- allow selecting any participant as the payer while keeping validation in place

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f5180a613483258d5f1640e42d1aeb


___

### **PR Type**
Enhancement


___

### **Description**
- Remove UI restriction preventing non-payer from paying group splits

- Allow any participant to be selected as payer in group bills

- Eliminate validation error and helper text for group split payments

- Simplify form logic by removing group split-specific constraints


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Group Split Form"] -- "Remove payer restriction" --> B["Any participant can pay"]
  A -- "Remove validation check" --> C["No group split error"]
  A -- "Remove UI disable state" --> D["Payer dropdown always enabled"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SplitForm.jsx</strong><dd><code>Remove group split payer restrictions and UI constraints</code>&nbsp; </dd></summary>
<hr>

src/components/SplitForm.jsx

<ul><li>Removed <code>useEffect</code> hook that forced payer to <code>YOU_ID</code> for group splits<br> <li> Deleted <code>isGroupSplit</code> variable and related conditional logic<br> <li> Removed <code>disabled={isGroupSplit}</code> attribute from payer select dropdown<br> <li> Removed validation error check preventing non-you participants from <br>paying group splits<br> <li> Removed helper text warning about group split payment restrictions</ul>


</details>


  </td>
  <td><a href="https://github.com/tasosbeast/bill-split/pull/10/files#diff-e19918dd976b8b805d771e718bc5f102128d33131c9181edeaa1cdd4815f8f10">+0/-25</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

