### PR TITLE
Reuse shared monthly budget selector in analytics dashboard

### DIFF
--- a/src/components/AnalyticsDashboard.jsx
+++ b/src/components/AnalyticsDashboard.jsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { formatEUR } from "../lib/money";
 import { CATEGORIES } from "../lib/categories";
-import { DEFAULT_MONTHLY_BUDGET } from "../lib/selectors";
+import { selectMonthlyBudget } from "../lib/selectors";
 import AnalyticsCard from "./AnalyticsCard";
 import AnalyticsCategoryList from "./AnalyticsCategoryList";
 import AnalyticsTrendChart from "./AnalyticsTrendChart";
@@ -22,20 +22,6 @@ import {
 
 function formatCurrency(value) {
   return formatEUR(value ?? 0);
-}
-
-function selectMonthlyBudget(state) {
-  const preferencesBudget = Number(state?.preferences?.monthlyBudget);
-  if (Number.isFinite(preferencesBudget) && preferencesBudget > 0) {
-    return preferencesBudget;
-  }
-
-  const directBudget = Number(state?.monthlyBudget);
-  if (Number.isFinite(directBudget) && directBudget > 0) {
-    return directBudget;
-  }
-
-  return DEFAULT_MONTHLY_BUDGET;
 }
 
 export default function AnalyticsDashboard({

--- a/src/lib/__tests__/selectors.test.js
+++ b/src/lib/__tests__/selectors.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MONTHLY_BUDGET, selectMonthlyBudget } from "../../lib/selectors";
+
+describe("selectMonthlyBudget", () => {
+  it("prefers the preferences monthly budget when valid", () => {
+    const state = { preferences: { monthlyBudget: 750 } };
+    expect(selectMonthlyBudget(state)).toBe(750);
+  });
+
+  it("coerces preference values provided as strings", () => {
+    const state = { preferences: { monthlyBudget: "625" } };
+    expect(selectMonthlyBudget(state)).toBe(625);
+  });
+
+  it("falls back to direct monthly budget when preference is invalid", () => {
+    const state = {
+      preferences: { monthlyBudget: -10 },
+      monthlyBudget: 820,
+    };
+    expect(selectMonthlyBudget(state)).toBe(820);
+  });
+
+  it("coerces direct monthly budget strings when preference is invalid", () => {
+    const state = {
+      preferences: { monthlyBudget: null },
+      monthlyBudget: "540",
+    };
+    expect(selectMonthlyBudget(state)).toBe(540);
+  });
+
+  it("returns the default budget when no valid value is provided", () => {
+    const state = {
+      preferences: { monthlyBudget: "abc" },
+      monthlyBudget: 0,
+    };
+    expect(selectMonthlyBudget(state)).toBe(DEFAULT_MONTHLY_BUDGET);
+  });
+});

--- a/src/lib/selectors.js
+++ b/src/lib/selectors.js
@@ -13,13 +13,15 @@ export function selectBalances(state) {
 }
 
 export function selectMonthlyBudget(state) {
-  const preferencesBudget = state?.preferences?.monthlyBudget;
-  const directBudget = state?.monthlyBudget;
-  const budget =
-    Number.isFinite(preferencesBudget) && preferencesBudget > 0
-      ? preferencesBudget
-      : Number.isFinite(directBudget) && directBudget > 0
-      ? directBudget
-      : DEFAULT_MONTHLY_BUDGET;
-  return budget;
+  const preferencesBudget = Number(state?.preferences?.monthlyBudget);
+  if (Number.isFinite(preferencesBudget) && preferencesBudget > 0) {
+    return preferencesBudget;
+  }
+
+  const directBudget = Number(state?.monthlyBudget);
+  if (Number.isFinite(directBudget) && directBudget > 0) {
+    return directBudget;
+  }
+
+  return DEFAULT_MONTHLY_BUDGET;
 }


### PR DESCRIPTION
### **User description**
## Summary
- update the shared monthly budget selector to coerce numeric strings before validation
- reuse the shared selector inside the analytics dashboard to avoid duplicating logic
- add tests covering numeric string inputs and fallback behaviour for the monthly budget selector

## Testing
- npm test -- --run
- npx vitest run src/lib/__tests__/selectors.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f57f30736c83258bfe4595e65c35d0


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactor `selectMonthlyBudget` to coerce numeric strings before validation

- Eliminate duplicate budget selector logic in AnalyticsDashboard component

- Add comprehensive test coverage for selector with edge cases

- Improve code reusability and maintainability across components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AnalyticsDashboard<br/>duplicate selector"] -->|refactor| B["Shared selectMonthlyBudget<br/>in selectors.js"]
  B -->|coerce strings| C["Number conversion<br/>before validation"]
  D["Test suite<br/>selectors.test.js"] -->|validates| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selectors.js</strong><dd><code>Add string coercion to monthly budget selector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/selectors.js

<ul><li>Refactored <code>selectMonthlyBudget</code> to coerce string inputs using <code>Number()</code> <br>conversion<br> <li> Restructured validation logic with early returns for improved <br>readability<br> <li> Maintains fallback chain: preferences budget → direct budget → default <br>budget<br> <li> Handles edge cases like negative values, null, and non-numeric strings</ul>


</details>


  </td>
  <td><a href="https://github.com/tasosbeast/bill-split/pull/20/files#diff-167988b4754b50cb4d4f22603d23bddecf09705e7d68a8c87fd0c9a1915256d1">+11/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AnalyticsDashboard.jsx</strong><dd><code>Reuse shared monthly budget selector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/AnalyticsDashboard.jsx

<ul><li>Removed duplicate <code>selectMonthlyBudget</code> function implementation<br> <li> Updated import to use shared selector from <code>lib/selectors</code><br> <li> Eliminated code duplication and improved maintainability</ul>


</details>


  </td>
  <td><a href="https://github.com/tasosbeast/bill-split/pull/20/files#diff-077c3e59d44c9511deb65f0ff081fa75a47e2bc4f99ff5db3fbf854eb7f5dd13">+1/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selectors.test.js</strong><dd><code>Add comprehensive selector test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/__tests__/selectors.test.js

<ul><li>Added 5 test cases covering numeric and string inputs<br> <li> Tests validate preference budget selection with valid numbers<br> <li> Tests verify string-to-number coercion for both preference and direct <br>budgets<br> <li> Tests ensure fallback to default budget for invalid inputs</ul>


</details>


  </td>
  <td><a href="https://github.com/tasosbeast/bill-split/pull/20/files#diff-8fc4de5949295c703f8444cbba87e9c7910055d381947ad29c68685808b0792e">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

