### PR TITLE
Add hidden labels to date range filter inputs

### DIFF
--- a/src/components/filters/DateRangeFilter.jsx
+++ b/src/components/filters/DateRangeFilter.jsx
@@ -27,6 +27,9 @@ export function DateRangeFilter({
     <fieldset className="filter-field" disabled={disabled}>
       <legend className="filter-label">{label}</legend>
       <div className="row gap-8">
+        <label className="sr-only" htmlFor={`${idPrefix}-start`}>
+          {`${label} start`}
+        </label>
         <input
           id={`${idPrefix}-start`}
           className="input"
@@ -37,6 +40,9 @@ export function DateRangeFilter({
         <span aria-hidden="true" className="filter-separator">
           –
         </span>
+        <label className="sr-only" htmlFor={`${idPrefix}-end`}>
+          {`${label} end`}
+        </label>
         <input
           id={`${idPrefix}-end`}
           className="input"


### PR DESCRIPTION
### **User description**
## Summary
- add visually hidden labels to the date range filter's start and end inputs so screen readers announce their purpose

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f62394ac94832596cab786ca77b384


___

### **PR Type**
Enhancement


___

### **Description**
- Add hidden labels to date range filter inputs

- Improve screen reader accessibility for start and end date inputs

- Labels use `sr-only` class for visual hiding


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DateRangeFilter Component"] -- "adds sr-only labels" --> B["Start Date Input"]
  A -- "adds sr-only labels" --> C["End Date Input"]
  B -- "announces purpose" --> D["Screen Readers"]
  C -- "announces purpose" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateRangeFilter.jsx</strong><dd><code>Add hidden labels for date range inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/filters/DateRangeFilter.jsx

<ul><li>Add visually hidden label for start date input with <code>sr-only</code> class<br> <li> Add visually hidden label for end date input with <code>sr-only</code> class<br> <li> Labels reference the filter label and append "start" or "end" for <br>clarity<br> <li> Improves accessibility for screen reader users</ul>


</details>


  </td>
  <td><a href="https://github.com/tasosbeast/bill-split/pull/21/files#diff-fb20a0412d11c19b254cb885d1378bfd17e0b94c1bd1b3b3b56ab1bed0a3e959">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

