### PR TITLE
Fix template handler redeclarations in legacy shell

### DIFF
--- a/src/features/legacyApp/LegacyAppShell.tsx
+++ b/src/features/legacyApp/LegacyAppShell.tsx
@@ -146,64 +146,6 @@ export default function LegacyAppShell(): JSX.Element {
     [pendingTemplate, handleAutomation, handleSplit]
   );
 
-  const handleAutomation = useCallback(
-    (transaction: StoredTransaction, automation: SplitAutomationRequest | null) => {
-      if (!automation || !automation.template) return;
-      const templateRequest = automation.template;
-      const existing = templateRequest?.templateId
-        ? templates.find((entry) => entry.id === templateRequest.templateId) ?? null
-        : null;
-      const record = templateFromTransaction(transaction, templateRequest, existing ?? undefined);
-      setTemplates((prev) => {
-        const next = [...prev];
-        const index = next.findIndex((entry) => entry.id === record.id);
-        if (index >= 0) {
-          next[index] = record;
-        } else {
-          next.unshift(record);
-        }
-        return next;
-      });
-    },
-    [setTemplates, templates]
-  );
-
-  const handleApplyTemplate = useCallback((template: TransactionTemplate) => {
-    setDraftPreset(buildDraftFromTemplate(template));
-  }, []);
-
-  const handleDeleteTemplate = useCallback(
-    (templateId: string) => {
-      setTemplates((prev) => prev.filter((entry) => entry.id !== templateId));
-      setDraftPreset((prev) => (prev?.templateId === templateId ? null : prev));
-    },
-    [setTemplates]
-  );
-
-  const handleGenerateFromTemplate = useCallback(
-    (template: TransactionTemplate) => {
-      const transaction = buildSplitTransaction({
-        total: template.total,
-        payer: template.payer,
-        participants: template.participants,
-        category: template.category,
-        note: template.note ?? template.name,
-        templateId: template.id,
-        templateName: template.name,
-      }) as StoredTransaction;
-      addTransaction(transaction);
-      if (template.recurrence) {
-        const nextRecurrence = advanceNextOccurrence(template.recurrence);
-        setTemplates((prev) =>
-          prev.map((entry) =>
-            entry.id === template.id ? { ...entry, recurrence: nextRecurrence } : entry
-          )
-        );
-      }
-    },
-    [addTransaction, setTemplates]
-  );
-
   const openRestoreModal = useCallback(() => setShowRestoreModal(true), []);
   const closeRestoreModal = useCallback(() => setShowRestoreModal(false), []);
 


### PR DESCRIPTION
### **User description**
## Summary
- remove duplicate template handler implementations from `LegacyAppShell` so the component relies on the hook-provided versions and avoids redeclaration errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f6c48819a083258be0037cedae62fe


___

### **PR Type**
Bug fix


___

### **Description**
- Remove duplicate template handler implementations from `LegacyAppShell`

- Eliminate redeclaration errors by relying on hook-provided versions

- Clean up `handleAutomation`, `handleApplyTemplate`, `handleDeleteTemplate`, and `handleGenerateFromTemplate` duplicates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LegacyAppShell<br/>with duplicate handlers"] -- "Remove redeclared<br/>functions" --> B["LegacyAppShell<br/>using hook versions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LegacyAppShell.tsx</strong><dd><code>Remove duplicate template handler implementations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/legacyApp/LegacyAppShell.tsx

<ul><li>Removed duplicate <code>handleAutomation</code> callback implementation<br> <li> Removed duplicate <code>handleApplyTemplate</code> callback implementation<br> <li> Removed duplicate <code>handleDeleteTemplate</code> callback implementation<br> <li> Removed duplicate <code>handleGenerateFromTemplate</code> callback implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/tasosbeast/bill-split/pull/28/files#diff-03c6a64f46b16eb2f6b992a3cc4c39887ffb6e5e5c551de3a62a70f3c34058e8">+0/-58</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

